### PR TITLE
Überspringe den Fall "nil == nil"

### DIFF
--- a/app/services/importer/waste_calendar.rb
+++ b/app/services/importer/waste_calendar.rb
@@ -35,8 +35,11 @@ class Importer::WasteCalendar
         next if date.blank?
 
         tour_connection_id = tour_data_line[@tour_assignment[waste_type_key]]
+        next if tour_connection_id.blank?
+
         @address_data.each do |address_data_line|
           address_connection_id = address_data_line[@address_assignment[waste_type_key]]
+          next if address_connection_id.blank?
           next if tour_connection_id != address_connection_id
 
           street = address_data_line.fetch(@address_assignment["street"], "")


### PR DESCRIPTION
In Zeile 43 konnte es vermutlich dazu kommen dass 'Lücken' gefüllt werden mit nicht existiernden Touren, wenn sowohl bei der Tour als auch bei der Adresse an einem Dateum nichts eingetragen war.

SVA-922