### PR TITLE
Änderungen an der Tour-Matrix speichern

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -222,3 +222,12 @@ h1 {
   background-color: #eaecf4;
   z-index: 2;
 }
+
+.data_table_matrix .confirmation {
+  background-color: #ffff00;
+  position: absolute;
+  z-index: 10;
+  display: block;
+  padding: 1px 5px;
+  margin-top: -25px;
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -118,6 +118,25 @@ $(function () {
     ]
   });
 
+  $('.matrix-checkbox').on('change', function () {
+    var $this = $(this);
+    var addressId = $this.data('address-id');
+    var tourId = $this.data('tour-id');
+    var checked = $this.is(':checked');
+
+    $.post('/waste_calendar/create_street_tour_matrix', {
+      location_tour: { [addressId]: { [tourId]: checked } }
+    }).done(function () {
+      var $confirmation = $('<div>', { class: 'confirmation' }).text('Änderung gespeichert!');
+      $this.closest('td').append($confirmation);
+      setTimeout(function () {
+        $confirmation.fadeOut(function () {
+          $confirmation.remove();
+        });
+      }, 500);
+    });
+  });
+
   // Toggle the side navigation
   $('#sidebarToggle, #sidebarToggleTop').on('click', function () {
     $('.sidebar, #sidebarToggleTop').toggleClass('toggled');

--- a/app/views/waste_calendar/new.html.erb
+++ b/app/views/waste_calendar/new.html.erb
@@ -13,7 +13,7 @@
     <%= render partial: "waste_calendar/new_tour_address" %>
 
     <% if @waste_locations && @waste_locations.any? %>
-      <%= form_with(url: "/waste_calendar/create_street_tour_matrix", method: :post, local: true) do |f| %>
+      <%= form_with(url: "#", method: :post, remote: true) do |f| %>
 
         <table class="table table-hover table-striped table-sm data_table_matrix nowrap">
           <thead class="thead-light">
@@ -45,16 +45,12 @@
               <% @waste_tours.each do |tour| %>
                 <td>
                   <%= hidden_field_tag "location_tour[#{location["id"]}][#{tour.id}]", false %>
-                  <%= check_box_tag "location_tour[#{location["id"]}][#{tour.id}]", true, selected_tour_ids.include?(tour.id), class: "matrix-checkbox" %>
+                  <%= check_box_tag "location_tour[#{location["id"]}][#{tour.id}]", true, selected_tour_ids.include?(tour.id), class: "matrix-checkbox", data: { address_id: location["id"], tour_id: tour.id } %>
                 </td>
               <% end %>
             </tr>
           <% end %>
         </table>
-
-        <div class="row justify-content-center pb-4">
-          <%= f.submit "Tour-Matrix speichern", class: "btn btn-primary" %>
-        </div>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
Die neueste Version der App enthält Funktionen, um nur noch Veränderungen an der Tour-Matrix zu speichern. Diese Änderungen ermöglichen es Benutzern, bestimmte Adressen für bestimmte Touren schneller zu speichern. Außerdem wird eine Bestätigung angezeigt, um dem Benutzer mitzuteilen, dass die Änderungen gespeichert wurden.

SVA-947

![2023-03-21 14-49-33 2023-03-21 14_54_35](https://user-images.githubusercontent.com/90779/226630359-d7785277-cc03-42dc-a086-0ec01c9d99d5.gif)

