### PR TITLE
Preiseingabe kann leer bleiben

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -311,7 +311,7 @@ class EventsController < ApplicationController
           next if price_information.blank?
           next unless nested_values?(price_information.to_h).include?(true)
 
-          price_information["amount"] = price_information["amount"].to_f if price_information["amount"].present?
+          price_information["amount"] = price_information["amount"].to_f if price_information["amount"].present? || price_information["description"].present?
           price_information["age_from"] = price_information["age_from"].present? ? price_information["age_from"].to_f : nil
           price_information["age_to"] = price_information["age_to"].present? ? price_information["age_to"].to_f : nil
           price_informations << price_information


### PR DESCRIPTION
Der Preis wird nun immer zu einem float umgewandelt, auch wenn er nicht angegeben ist.
Vorraussetzung dafür ist, das dann wenigstens die Beschreibung ausgefüllt ist:

Wenn also die Beschreibung des Preises oder der Wert Preis angegeben ist, dann wird der Wert des preises immer zu einem Float umgewandelt, was nun auch bei einem freilassen zu 0.0 führt.

Die führt nun nicht mehr zu einem Fehler, wenn eine kostenlose Preiskategorie angegeben werden soll, bei der nur die Beschreibung ausgefüllt wurde.

SVA-1090