### PR TITLE
feat(event): recurring dates

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -188,6 +188,10 @@ class EventsController < ApplicationController
               description
             }
           }
+          recurring
+          recurringWeekdays
+          recurringType
+          recurringInterval
         }
       }
     GRAPHQL

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -23,6 +23,7 @@ class EventsController < ApplicationController
             dateStart
             dateEnd
           }
+          recurring
           updatedAt
           createdAt
         }

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -82,6 +82,10 @@
           requireds: ['date_start'],
           force_visibility: true
       }) %>
+  <%= render(
+        partial: "shared/partials/recurring_dates_form",
+        locals: { record: event, form: f }
+      ) %>
 
   <div class="row">
     <div class="col">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -29,7 +29,13 @@
           <th scope="row"><%= event.id %></th>
           <td><%= link_to event.title, edit_event_path(event.id) %></td>
           <td><%= event.categories.first.try(:name) %></td>
-          <td><%= event.dates.map { |date| "Start: #{toLocalDate(date.date_start)} - Ende: #{toLocalDate(date.date_end)}" }.join("<br />").html_safe %></td>
+          <td>
+            <%= event.dates.map { |date| "Start: #{toLocalDate(date.date_start)} - Ende: #{toLocalDate(date.date_end)}" }.join("<br />").html_safe %>
+            <% if event.recurring %>
+              <br />
+              <span class="badge badge-secondary">wiederkehrend</span>
+            <% end %>
+          </td>
           <td><%= toLocalDateTime(event.updated_at) %></td>
           <td><%= toLocalDateTime(event.created_at) %></td>
           <% if editor? %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -30,10 +30,13 @@
           <td><%= link_to event.title, edit_event_path(event.id) %></td>
           <td><%= event.categories.first.try(:name) %></td>
           <td>
-            <%= event.dates.map { |date| "Start: #{toLocalDate(date.date_start)} - Ende: #{toLocalDate(date.date_end)}" }.join("<br />").html_safe %>
             <% if event.recurring %>
+              <% date = event.dates.first %>
+              <%= "Start: #{toLocalDate(date.date_start)} - Ende: #{toLocalDate(date.date_end)}" %>
               <br />
               <span class="badge badge-secondary">wiederkehrend</span>
+            <% else %>
+              <%= event.dates.map { |date| "Start: #{toLocalDate(date.date_start)} - Ende: #{toLocalDate(date.date_end)}" }.join("<br />").html_safe %>
             <% end %>
           </td>
           <td><%= toLocalDateTime(event.updated_at) %></td>

--- a/app/views/shared/partials/_dates_form.html.erb
+++ b/app/views/shared/partials/_dates_form.html.erb
@@ -39,7 +39,9 @@
                       :date_start,
                       required: requireds.include?("date_start"),
                       class: "form-control",
-                      value: fd.object.date_start || values[:date_start].presence
+                      value: fd.object.date_start || values[:date_start].presence,
+                      max: (Time.now + 50.years).end_of_year.to_date.to_s,
+                      pattern: "\d{4}-\d{2}-\d{2}"
                     ) %>
               </div>
             </div>
@@ -59,7 +61,9 @@
                       :date_end,
                       required: requireds.include?("date_end"),
                       class: "form-control",
-                      value: fd.object.date_end || values[:date_end].presence
+                      value: fd.object.date_end || values[:date_end].presence,
+                      max: (Time.now + 50.years).end_of_year.to_date.to_s,
+                      pattern: "\d{4}-\d{2}-\d{2}"
                     ) %>
               </div>
             </div>
@@ -83,7 +87,8 @@
                         :time_start,
                         required: requireds.include?("time_start"),
                         class: "form-control",
-                        value: fd.object.time_start || values[:time_start].presence
+                        value: fd.object.time_start || values[:time_start].presence,
+                        pattern: "[0-9]{2}:[0-9]{2}"
                       ) %>
                 </div>
               </div>
@@ -103,7 +108,8 @@
                         :time_end,
                         required: requireds.include?("time_end"),
                         class: "form-control",
-                        value: fd.object.time_end || values[:time_end].presence
+                        value: fd.object.time_end || values[:time_end].presence,
+                        pattern: "[0-9]{2}:[0-9]{2}"
                       ) %>
                 </div>
               </div>

--- a/app/views/shared/partials/_dates_form.html.erb
+++ b/app/views/shared/partials/_dates_form.html.erb
@@ -23,7 +23,7 @@
   if we have an event with recurring dates, we just want to show the first date, because
   the others are generated and are not allowed to be edited
 %>
-<% if record.recurring? %>
+<% if record.try(:recurring?) %>
   <% list_of_dates = [record.dates.first] %>
 <% end %>
 

--- a/app/views/shared/partials/_dates_form.html.erb
+++ b/app/views/shared/partials/_dates_form.html.erb
@@ -19,6 +19,14 @@
   <% list_of_dates = [record.date] %>
 <% end %>
 
+<%#
+  if we have an event with recurring dates, we just want to show the first date, because
+  the others are generated and are not allowed to be edited
+%>
+<% if record.recurring? %>
+  <% list_of_dates = [record.dates.first] %>
+<% end %>
+
 <div id="nested-dates">
   <% list_of_dates.each_with_index do |date, index| %>
     <%= form.fields_for "dates[#{index}]", date do |fd| %>

--- a/app/views/shared/partials/_push_notifications_form.html.erb
+++ b/app/views/shared/partials/_push_notifications_form.html.erb
@@ -1,4 +1,4 @@
-<% fields = ["once_at", "recurring", "title", "body"] %>
+<% fields = ["once_at", "title", "body"] %>
 <% list_of_push_notifications = record.push_notifications.presence || [OpenStruct.new] %>
 
 <div class="row">
@@ -22,7 +22,7 @@
           </div>
 
           <div class="card-body">
-            <div class="row collapse recurring-collapse <%= fpn.object.recurring.blank? || fpn.object.recurring.try(:zero?) ? "show" : "" %>">
+            <div class="row">
               <div class="col-lg-6">
                 <div class="form-group">
                   <%= fpn.label :once_at, "Einmalig am/um" %>

--- a/app/views/shared/partials/_recurring_dates_form.html.erb
+++ b/app/views/shared/partials/_recurring_dates_form.html.erb
@@ -29,7 +29,8 @@
       <%= form.number_field(
             :recurring_interval,
             class: "form-control",
-            value: record.recurring_interval || 1
+            value: record.recurring_interval || 2,
+            min: 2
           ) %>
     </div>
   </div>
@@ -90,6 +91,13 @@
       $('.recurring-weekdays-collapse').addClass('show');
     } else {
       $('.recurring-weekdays-collapse').removeClass('show');
+    }
+
+    // do not allow a recurring pattern for "every day", as this is the default without a pattern
+    if (e.target.value == 0) {
+        $('#event_recurring_interval').prop('min', 2);
+    } else {
+      $('#event_recurring_interval').prop('min', 1);
     }
   });
 </script>

--- a/app/views/shared/partials/_recurring_dates_form.html.erb
+++ b/app/views/shared/partials/_recurring_dates_form.html.erb
@@ -1,0 +1,81 @@
+<% weekdays = ["Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag", "Sonntag"] %>
+<% recurring_types = [["Tag(e)", 0], ["Woche(n)", 1], ["Monat(e)", 2], ["Jahr(e)", 3]] %>
+
+<div class="row">
+  <div class="col-12">
+    <h5>Veranstaltungsserie</h5>
+    <p>
+      Erstellen Sie eine Veranstaltungsserie, indem Sie die gewünschten Wiederholungen festlegen.
+    <p>
+  </div>
+
+  <div class="col-12">
+    <div class="form-group">
+      <%= form.check_box(
+            :recurring,
+            { data: { toggle: "collapse", target: ".recurring-collapse" } },
+            1,
+            0
+          ) %>
+      <%= form.label :recurring, "Veranstaltung wiederholen" %>
+    </div>
+  </div>
+</div>
+
+<div class="row collapse recurring-collapse <%= record.recurring ? "show" : "" %>">
+  <div class="col-lg-6">
+    <div class="form-group">
+      <%= form.label :recurring_interval, "Jede/Alle" %>
+      <%= form.number_field(
+            :recurring_interval,
+            class: "form-control",
+            value: record.recurring_interval || 1
+          ) %>
+    </div>
+  </div>
+
+  <div class="col-lg-6">
+    <div class="form-group">
+      <%= form.label :recurring_type, "&nbsp;".html_safe, class: "d-none d-lg-block" %>
+      <%= form.select :recurring_type, recurring_types, {}, class: "form-control custom-select" %>
+    </div>
+  </div>
+
+  <div class="col-lg-12 collapse recurring-weekdays-collapse <%= record.recurring_type == 1 ? "show" : "" %>">
+    <div class="form-group">
+      <% weekdays.each_with_index do |weekday, index| %>
+        <span class="mr-3 text-nowrap">
+          <%= form.check_box(
+                :recurring_weekdays,
+                { multiple: true },
+                index,
+                nil
+              ) %>
+          <%= form.label :recurring_weekdays, weekday, for: "event_recurring_weekdays_#{index}" %>
+        </span>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<script>
+  if ($('#event_recurring').is(':checked')) {
+    $('.recurring-collapse').addClass('show');
+  } else {
+    $('.recurring-collapse').removeClass('show');
+  }
+
+  if ($('#event_recurring_type').val() == 1) {
+    $('.recurring-weekdays-collapse').addClass('show');
+  } else {
+    $('.recurring-weekdays-collapse').removeClass('show');
+  }
+
+  $('#event_recurring_type').change(function (e) {
+    if (e.target.value == 1) {
+      $('.recurring-weekdays-collapse').addClass('show');
+    } else {
+      $('.recurring-weekdays-collapse').removeClass('show');
+    }
+  });
+</script>

--- a/app/views/shared/partials/_recurring_dates_form.html.erb
+++ b/app/views/shared/partials/_recurring_dates_form.html.erb
@@ -61,9 +61,23 @@
 <script>
   if ($('#event_recurring').is(':checked')) {
     $('.recurring-collapse').addClass('show');
+      $('#event_dates_0__date_end').prop('required', true);
+      $('#event_dates_0__date_end').prev().text('Enddatum *');
   } else {
     $('.recurring-collapse').removeClass('show');
+      $('#event_dates_0__date_end').prop('required', false);
+      $('#event_dates_0__date_end').prev().text('Enddatum');
   }
+
+  $('#event_recurring').change(function (e) {
+    if ($('#event_recurring').is(':checked')) {
+      $('#event_dates_0__date_end').prop('required', true);
+      $('#event_dates_0__date_end').prev().text('Enddatum *');
+    } else {
+      $('#event_dates_0__date_end').prop('required', false);
+      $('#event_dates_0__date_end').prev().text('Enddatum');
+    }
+  });
 
   if ($('#event_recurring_type').val() == 1) {
     $('.recurring-weekdays-collapse').addClass('show');

--- a/app/views/shared/partials/_recurring_dates_form.html.erb
+++ b/app/views/shared/partials/_recurring_dates_form.html.erb
@@ -6,7 +6,7 @@
     <h5>Veranstaltungsserie</h5>
     <p>
       Erstellen Sie eine Veranstaltungsserie, indem Sie die gewünschten Wiederholungen festlegen.
-    <p>
+    </p>
   </div>
 
   <div class="col-12">


### PR DESCRIPTION
This PR introduces an interface to setup recurring dates for events.

| Not recurring | Recurring every day | Recurring on few days every two weeks | Recurring every four months | Recurring every year |
| --------------- | --------------- | --------------- | --------------- | --------------- |
| <img width="922" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-cms/assets/1942953/6a683dff-8653-434d-9930-1dca13a2f679"> | <img width="922" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-cms/assets/1942953/c960f0bd-e213-42ec-88be-022b0aaef3a1"> | <img width="929" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-cms/assets/1942953/0d19f125-b662-437f-be95-01f763079b76"> | <img width="921" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-cms/assets/1942953/d293a44b-bfee-4ebf-9c99-bc7ba4693fc2"> | <img width="927" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-cms/assets/1942953/e89bcaa2-cd37-45e8-8245-505838161be9"> |

The end date of an event is set to required for setting up a recurring pattern. Otherwise we would not be able to find an end.
The maximum future year is reduced to 50 years from now to avoid very very large amounts of data stored to databases.

On the index page there is a new badge that indicates an event with recurring dates:

<img width="1383" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-cms/assets/1942953/d2eb627b-ca3d-43ff-abe1-13ab27d61413">

Relating PR on the main-server can be found here: https://github.com/smart-village-solutions/smart-village-app-mainserver/pull/408

SVA-1009