### PR TITLE
feat: added category display to POI and tours in list view

### DIFF
--- a/app/controllers/point_of_interests_controller.rb
+++ b/app/controllers/point_of_interests_controller.rb
@@ -12,8 +12,11 @@ class PointOfInterestsController < ApplicationController
         pointsOfInterest {
           id
           name
+          categories {
+            name
+          }
           visible
-          dataProvider{
+          dataProvider {
             name
           }
           updatedAt

--- a/app/controllers/tours_controller.rb
+++ b/app/controllers/tours_controller.rb
@@ -12,6 +12,9 @@ class ToursController < ApplicationController
         tours {
           id
           name
+          categories {
+            name
+          }
           visible
           dataProvider {
             name

--- a/app/views/point_of_interests/index.html.erb
+++ b/app/views/point_of_interests/index.html.erb
@@ -12,6 +12,7 @@
       <tr>
         <th scope="col">ID</th>
         <th scope="col">Überschrift</th>
+        <th scope="col">Kategorie</th>
         <th scope="col">Änderungsdatum</th>
         <th scope="col">Erstellungsdatum</th>
         <% if editor? %>
@@ -26,6 +27,7 @@
         <tr>
           <th scope="row"><%= poi.id %></th>
           <td><%= link_to poi.name, edit_point_of_interest_path(poi.id) %></td>
+          <td><%= poi.categories.first.try(:name) %></td>
           <td data-sort="<%= DateTime.parse(poi.updated_at).to_i %>">
             <%= to_local_date_time(poi.updated_at) %>
           </td>

--- a/app/views/tours/index.html.erb
+++ b/app/views/tours/index.html.erb
@@ -12,6 +12,7 @@
       <tr>
         <th scope="col">ID</th>
         <th scope="col">Überschrift</th>
+        <th scope="col">Kategorie</th>
         <th scope="col">Änderungsdatum</th>
         <th scope="col">Erstellungsdatum</th>
         <% if editor? %>
@@ -26,6 +27,7 @@
         <tr>
           <th scope="row"><%= tour.id %></th>
           <td><%= link_to tour.name, edit_tour_path(tour.id) %></td>
+          <td><%= tour.categories.first.try(:name) %></td>
           <td data-sort="<%= DateTime.parse(tour.updated_at).to_i %>">
             <%= to_local_date_time(tour.updated_at) %>
           </td>


### PR DESCRIPTION
Extended the category display feature, which was already present in the Events and News list views, to now also show in the POI (Point of Interest) and Tours list views.

<img width="491" alt="tour" src="https://github.com/smart-village-solutions/smart-village-app-cms/assets/30198351/a8ec81c9-a9d7-4dcd-bbcc-a10402cdda37">
<img width="324" alt="place" src="https://github.com/smart-village-solutions/smart-village-app-cms/assets/30198351/836c6cb0-cc4a-487c-83e5-95f9d019cef5">


SVA-1121