### PR TITLE
fix: sorting function for date fields

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,6 +27,10 @@ module ApplicationHelper
     date_time.to_datetime.in_time_zone("Berlin").strftime("%d.%m.%Y %H:%M Uhr")
   end
 
+  def to_unix_timestamp(date)
+    date.present? ? DateTime.parse(date.to_s).to_i : 0
+  end
+
   def visibility_switch(item, item_class)
     input_switch = check_box_tag(
       "visible-#{item.id}",

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,13 +15,13 @@ module ApplicationHelper
     false
   end
 
-  def toLocalDate(date)
+  def to_local_date(date)
     return "" unless date.present?
 
     date.to_date.in_time_zone("Berlin").strftime("%d.%m.%Y")
   end
 
-  def toLocalDateTime(date_time)
+  def to_local_date_time(date_time)
     return "" unless date_time.present?
 
     date_time.to_datetime.in_time_zone("Berlin").strftime("%d.%m.%Y %H:%M Uhr")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,7 +28,9 @@ module ApplicationHelper
   end
 
   def to_unix_timestamp(date)
-    date.present? ? DateTime.parse(date.to_s).to_i : 0
+    return 0 unless date.present?
+
+    DateTime.parse(date.to_s).to_i
   end
 
   def visibility_switch(item, item_class)

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -83,7 +83,16 @@ $(function () {
 
   $('.data_table').DataTable({
     searching: true,
+    language: {
+      url: '//cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/German.json'
+    },
     order: [[0, 'desc']],
+    columnDefs: [
+      {
+        bSortable: false,
+        targets: 'nosort'
+      }
+    ]
   });
 
   $('.data_table_matrix').DataTable({
@@ -93,7 +102,16 @@ $(function () {
     fixedColumns: {
       left: 1
     },
+    language: {
+      url: '//cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/German.json'
+    },
     order: [[0, 'asc']],
+    columnDefs: [
+      {
+        bSortable: false,
+        targets: 'nosort'
+      }
+    ]
   });
 
   $('.matrix-checkbox').on('change', function () {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,12 +7,10 @@ require('@rails/ujs').start();
 require('@rails/activestorage').start();
 require('jquery');
 require('jquery.easing');
-require('moment');
 require('bootstrap/dist/js/bootstrap.bundle.min.js');
 require('@fortawesome/fontawesome-free/js/all.js');
 var DataTable = require('datatables.net/js/jquery.dataTables.js');
 require('datatables.net-bs4/js/dataTables.bootstrap4.js');
-require('datatable-sorting-datetime-moment');
 require('datatables.net-fixedcolumns');
 require('channels');
 require('@kanety/jquery-nested-form');
@@ -76,8 +74,6 @@ $(function () {
 
   // Init DataTables for all tables with css-class 'data_table'
   $.fn.dataTable = DataTable;
-  $.fn.dataTable.moment('DD.MM.YYYY HH:mm [Uhr]');
-  $.fn.dataTable.moment('DD.MM.YYYY');
   $.fn.dataTableSettings = DataTable.settings;
   $.fn.dataTableExt = DataTable.ext;
   DataTable.$ = $;
@@ -87,16 +83,7 @@ $(function () {
 
   $('.data_table').DataTable({
     searching: true,
-    language: {
-      url: '//cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/German.json'
-    },
     order: [[0, 'desc']],
-    columnDefs: [
-      {
-        bSortable: false,
-        targets: 'nosort'
-      }
-    ]
   });
 
   $('.data_table_matrix').DataTable({
@@ -106,16 +93,7 @@ $(function () {
     fixedColumns: {
       left: 1
     },
-    language: {
-      url: '//cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/German.json'
-    },
     order: [[0, 'asc']],
-    columnDefs: [
-      {
-        bSortable: false,
-        targets: 'nosort'
-      }
-    ]
   });
 
   $('.matrix-checkbox').on('change', function () {

--- a/app/views/constructions/index.html.erb
+++ b/app/views/constructions/index.html.erb
@@ -27,8 +27,12 @@
         <tr>
           <th scope="row"><%= construction.id %></th>
           <td><%= link_to construction.title, edit_construction_path(construction.id) %></td>
-          <td><%= toLocalDate(construction.dates.try(:first).try(:date_start)) %></td>
-          <td><%= toLocalDate(construction.dates.try(:first).try(:date_end)) %></td>
+          <td data-sort="<%= to_unix_timestamp(construction.dates.try(:first).try(:date_start)) %>">
+            <%= toLocalDate(construction.dates.try(:first).try(:date_start)) %>
+          </td>
+          <td data-sort="<%= to_unix_timestamp(construction.dates.try(:first).try(:date_end)) %>">
+            <%= toLocalDate(construction.dates.try(:first).try(:date_end)) %>
+          </td>
           <td data-sort="<%= DateTime.parse(construction.updated_at).to_i %>">
             <%= toLocalDateTime(construction.updated_at) %>
           </td>

--- a/app/views/constructions/index.html.erb
+++ b/app/views/constructions/index.html.erb
@@ -28,16 +28,16 @@
           <th scope="row"><%= construction.id %></th>
           <td><%= link_to construction.title, edit_construction_path(construction.id) %></td>
           <td data-sort="<%= to_unix_timestamp(construction.dates.try(:first).try(:date_start)) %>">
-            <%= toLocalDate(construction.dates.try(:first).try(:date_start)) %>
+            <%= to_local_date(construction.dates.try(:first).try(:date_start)) %>
           </td>
           <td data-sort="<%= to_unix_timestamp(construction.dates.try(:first).try(:date_end)) %>">
-            <%= toLocalDate(construction.dates.try(:first).try(:date_end)) %>
+            <%= to_local_date(construction.dates.try(:first).try(:date_end)) %>
           </td>
           <td data-sort="<%= DateTime.parse(construction.updated_at).to_i %>">
-            <%= toLocalDateTime(construction.updated_at) %>
+            <%= to_local_date_time(construction.updated_at) %>
           </td>
           <td data-sort="<%= DateTime.parse(construction.created_at).to_i %>">
-            <%= toLocalDateTime(construction.created_at) %>
+            <%= to_local_date_time(construction.created_at) %>
           </td>
           <% if editor? %>
             <td><%= construction.data_provider.try(:name) %></td>

--- a/app/views/constructions/index.html.erb
+++ b/app/views/constructions/index.html.erb
@@ -29,8 +29,12 @@
           <td><%= link_to construction.title, edit_construction_path(construction.id) %></td>
           <td><%= toLocalDate(construction.dates.try(:first).try(:date_start)) %></td>
           <td><%= toLocalDate(construction.dates.try(:first).try(:date_end)) %></td>
-          <td><%= toLocalDateTime(construction.updated_at) %></td>
-          <td><%= toLocalDateTime(construction.created_at) %></td>
+          <td data-sort="<%= DateTime.parse(construction.updated_at).to_i %>">
+            <%= toLocalDateTime(construction.updated_at) %>
+          </td>
+          <td data-sort="<%= DateTime.parse(construction.created_at).to_i %>">
+            <%= toLocalDateTime(construction.created_at) %>
+          </td>
           <% if editor? %>
             <td><%= construction.data_provider.try(:name) %></td>
           <% end %>

--- a/app/views/deadlines/index.html.erb
+++ b/app/views/deadlines/index.html.erb
@@ -29,13 +29,13 @@
           <td><%= link_to deadline.title, edit_deadline_path(deadline.id) %></td>
           <td><%= deadline.categories.first.try(:name) || "" %></td>
           <td data-sort="<%= to_unix_timestamp(deadline.dates.try(:first).try(:date_start)) %>">
-            <%= toLocalDate(deadline.dates.try(:first).try(:date_start)) %>
+            <%= to_local_date(deadline.dates.try(:first).try(:date_start)) %>
           </td>
           <td data-sort="<%= DateTime.parse(deadline.updated_at).to_i %>">
-            <%= toLocalDateTime(deadline.updated_at) %>
+            <%= to_local_date_time(deadline.updated_at) %>
           </td>
           <td data-sort="<%= DateTime.parse(deadline.created_at).to_i %>">
-            <%= toLocalDateTime(deadline.created_at) %>
+            <%= to_local_date_time(deadline.created_at) %>
           </td>
           <% if editor? %>
             <td><%= deadline.data_provider.try(:name) %></td>

--- a/app/views/deadlines/index.html.erb
+++ b/app/views/deadlines/index.html.erb
@@ -28,7 +28,9 @@
           <th scope="row"><%= deadline.id %></th>
           <td><%= link_to deadline.title, edit_deadline_path(deadline.id) %></td>
           <td><%= deadline.categories.first.try(:name) || "" %></td>
-          <td><%= toLocalDate(deadline.dates.try(:first).try(:date_start)) %></td>
+          <td data-sort="<%= to_unix_timestamp(deadline.dates.try(:first).try(:date_start)) %>">
+            <%= toLocalDate(deadline.dates.try(:first).try(:date_start)) %>
+          </td>
           <td data-sort="<%= DateTime.parse(deadline.updated_at).to_i %>">
             <%= toLocalDateTime(deadline.updated_at) %>
           </td>

--- a/app/views/deadlines/index.html.erb
+++ b/app/views/deadlines/index.html.erb
@@ -29,8 +29,12 @@
           <td><%= link_to deadline.title, edit_deadline_path(deadline.id) %></td>
           <td><%= deadline.categories.first.try(:name) || "" %></td>
           <td><%= toLocalDate(deadline.dates.try(:first).try(:date_start)) %></td>
-          <td><%= toLocalDateTime(deadline.updated_at) %></td>
-          <td><%= toLocalDateTime(deadline.created_at) %></td>
+          <td data-sort="<%= DateTime.parse(deadline.updated_at).to_i %>">
+            <%= toLocalDateTime(deadline.updated_at) %>
+          </td>
+          <td data-sort="<%= DateTime.parse(deadline.created_at).to_i %>">
+            <%= toLocalDateTime(deadline.created_at) %>
+          </td>
           <% if editor? %>
             <td><%= deadline.data_provider.try(:name) %></td>
           <% end %>

--- a/app/views/defect_reports/index.html.erb
+++ b/app/views/defect_reports/index.html.erb
@@ -38,8 +38,12 @@
                 ) %>
           </td>
           <td><%= defect_report.categories.first.try(:name) || "" %></td>
-          <td><%= toLocalDateTime(defect_report.updated_at) %></td>
-          <td><%= toLocalDateTime(defect_report.created_at) %></td>
+          <td data-sort="<%= DateTime.parse(defect_report.updated_at).to_i %>">
+            <%= toLocalDateTime(defect_report.updated_at) %>
+          </td>
+          <td data-sort="<%= DateTime.parse(defect_report.created_at).to_i %>">
+            <%= toLocalDateTime(defect_report.created_at) %>
+          </td>
           <% if editor? %>
             <td><%= defect_report.data_provider.try(:name) %></td>
             <td align="center"><%= visibility_switch(defect_report, "defect_report") %></td>

--- a/app/views/defect_reports/index.html.erb
+++ b/app/views/defect_reports/index.html.erb
@@ -39,10 +39,10 @@
           </td>
           <td><%= defect_report.categories.first.try(:name) || "" %></td>
           <td data-sort="<%= DateTime.parse(defect_report.updated_at).to_i %>">
-            <%= toLocalDateTime(defect_report.updated_at) %>
+            <%= to_local_date_time(defect_report.updated_at) %>
           </td>
           <td data-sort="<%= DateTime.parse(defect_report.created_at).to_i %>">
-            <%= toLocalDateTime(defect_report.created_at) %>
+            <%= to_local_date_time(defect_report.created_at) %>
           </td>
           <% if editor? %>
             <td><%= defect_report.data_provider.try(:name) %></td>

--- a/app/views/encounters_supports/show.html.erb
+++ b/app/views/encounters_supports/show.html.erb
@@ -71,8 +71,8 @@
     <tbody>
       <% @encounters.each do |encounter| %>
         <tr>
-          <td data-updated-at="<%= toLocalDateTime(encounter["updated_at"]) %>">
-            <%= toLocalDateTime(encounter["created_at"]) %>
+          <td data-updated-at="<%= to_local_date_time(encounter["updated_at"]) %>">
+            <%= to_local_date_time(encounter["created_at"]) %>
           </td>
           <td>
             <% if encounter["user_provided"]["user_uuid"] != @user["user_uuid"] %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -32,18 +32,18 @@
           <td>
             <% if event.recurring %>
               <% date = event.dates.first %>
-              <%= "Start: #{toLocalDate(date.date_start)} - Ende: #{toLocalDate(date.date_end)}" %>
+              <%= "Start: #{to_local_date(date.date_start)} - Ende: #{to_local_date(date.date_end)}" %>
               <br />
               <span class="badge badge-secondary">wiederkehrend</span>
             <% else %>
-              <%= event.dates.map { |date| "Start: #{toLocalDate(date.date_start)} - Ende: #{toLocalDate(date.date_end)}" }.join("<br />").html_safe %>
+              <%= event.dates.map { |date| "Start: #{to_local_date(date.date_start)} - Ende: #{to_local_date(date.date_end)}" }.join("<br />").html_safe %>
             <% end %>
           </td>
           <td data-sort="<%= DateTime.parse(event.updated_at).to_i %>">
-            <%= toLocalDateTime(event.updated_at) %>
+            <%= to_local_date_time(event.updated_at) %>
           </td>
           <td data-sort="<%= DateTime.parse(event.created_at).to_i %>">
-            <%= toLocalDateTime(event.created_at) %>
+            <%= to_local_date_time(event.created_at) %>
           </td>
           <% if editor? %>
             <td><%= event.data_provider.try(:name) %></td>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -39,8 +39,12 @@
               <%= event.dates.map { |date| "Start: #{toLocalDate(date.date_start)} - Ende: #{toLocalDate(date.date_end)}" }.join("<br />").html_safe %>
             <% end %>
           </td>
-          <td><%= toLocalDateTime(event.updated_at) %></td>
-          <td><%= toLocalDateTime(event.created_at) %></td>
+          <td data-sort="<%= DateTime.parse(event.updated_at).to_i %>">
+            <%= toLocalDateTime(event.updated_at) %>
+          </td>
+          <td data-sort="<%= DateTime.parse(event.created_at).to_i %>">
+            <%= toLocalDateTime(event.created_at) %>
+          </td>
           <% if editor? %>
             <td><%= event.data_provider.try(:name) %></td>
             <td align="center"><%= visibility_switch(event, "EventRecord") %></td>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -31,8 +31,12 @@
           <td><%= (job.payload || {})["employmentType"] %></td>
           <td><%= toLocalDate(job.publication_date.try(:to_date)) %></td>
           <td><%= toLocalDate(job.dates.try(:first).try(:date_end)) %></td>
-          <td><%= toLocalDateTime(job.updated_at) %></td>
-          <td><%= toLocalDateTime(job.created_at) %></td>
+          <td data-sort="<%= DateTime.parse(job.updated_at).to_i %>">
+            <%= toLocalDateTime(job.updated_at) %>
+          </td>
+          <td data-sort="<%= DateTime.parse(job.created_at).to_i %>">
+            <%= toLocalDateTime(job.created_at) %>
+          </td>
           <% if editor? %>
             <td><%= job.data_provider.try(:name) %></td>
           <% end %>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -30,16 +30,16 @@
           <td><%= link_to job.title, edit_job_path(job.id) %></td>
           <td><%= (job.payload || {})["employmentType"] %></td>
           <td data-sort="<%= to_unix_timestamp(job.publication_date.try(:to_date)) %>">
-            <%= toLocalDate(job.publication_date.try(:to_date)) %>
+            <%= to_local_date(job.publication_date.try(:to_date)) %>
           </td>
           <td data-sort="<%= to_unix_timestamp(job.dates.try(:first).try(:date_end)) %>">
-            <%= toLocalDate(job.dates.try(:first).try(:date_end)) %>
+            <%= to_local_date(job.dates.try(:first).try(:date_end)) %>
           </td>
           <td data-sort="<%= DateTime.parse(job.updated_at).to_i %>">
-            <%= toLocalDateTime(job.updated_at) %>
+            <%= to_local_date_time(job.updated_at) %>
           </td>
           <td data-sort="<%= DateTime.parse(job.created_at).to_i %>">
-            <%= toLocalDateTime(job.created_at) %>
+            <%= to_local_date_time(job.created_at) %>
           </td>
           <% if editor? %>
             <td><%= job.data_provider.try(:name) %></td>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -29,8 +29,12 @@
           <th scope="row"><%= job.id %></th>
           <td><%= link_to job.title, edit_job_path(job.id) %></td>
           <td><%= (job.payload || {})["employmentType"] %></td>
-          <td><%= toLocalDate(job.publication_date.try(:to_date)) %></td>
-          <td><%= toLocalDate(job.dates.try(:first).try(:date_end)) %></td>
+          <td data-sort="<%= to_unix_timestamp(job.publication_date.try(:to_date)) %>">
+            <%= toLocalDate(job.publication_date.try(:to_date)) %>
+          </td>
+          <td data-sort="<%= to_unix_timestamp(job.dates.try(:first).try(:date_end)) %>">
+            <%= toLocalDate(job.dates.try(:first).try(:date_end)) %>
+          </td>
           <td data-sort="<%= DateTime.parse(job.updated_at).to_i %>">
             <%= toLocalDateTime(job.updated_at) %>
           </td>

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -38,10 +38,10 @@
           <% end %>
           <td><%= news_item.categories.first.try(:name) %></td>
           <td data-sort="<%= DateTime.parse(news_item.updated_at).to_i %>">
-            <%= toLocalDateTime(news_item.updated_at) %>
+            <%= to_local_date_time(news_item.updated_at) %>
           </td>
           <td data-sort="<%= DateTime.parse(news_item.created_at).to_i %>">
-            <%= toLocalDateTime(news_item.created_at) %>
+            <%= to_local_date_time(news_item.created_at) %>
           </td>
           <% if editor? %>
             <td><%= news_item.data_provider.try(:name) %></td>

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -37,8 +37,12 @@
             <td><%= news_item.title.presence || news_item.content_blocks.first.try(:title) %></td>
           <% end %>
           <td><%= news_item.categories.first.try(:name) %></td>
-          <td><%= toLocalDateTime(news_item.updated_at) %></td>
-          <td><%= toLocalDateTime(news_item.created_at) %></td>
+          <td data-sort="<%= DateTime.parse(news_item.updated_at).to_i %>">
+            <%= toLocalDateTime(news_item.updated_at) %>
+          </td>
+          <td data-sort="<%= DateTime.parse(news_item.created_at).to_i %>">
+            <%= toLocalDateTime(news_item.created_at) %>
+          </td>
           <% if editor? %>
             <td><%= news_item.data_provider.try(:name) %></td>
             <td align="center"><%= visibility_switch(news_item, "NewsItem") %></td>

--- a/app/views/noticeboards/index.html.erb
+++ b/app/views/noticeboards/index.html.erb
@@ -43,16 +43,16 @@
           <td><%= noticeboard.categories.first.try(:name) || "" %></td>
           <td><%= noticeboard.generic_item_messages.count %></td>
           <td data-sort="<%= to_unix_timestamp(noticeboard.dates.try(:first).try(:date_start)) %>">
-            <%= toLocalDate(noticeboard.dates.try(:first).try(:date_start)) %>
+            <%= to_local_date(noticeboard.dates.try(:first).try(:date_start)) %>
           </td>
           <<td data-sort="<%= to_unix_timestamp(noticeboard.dates.try(:first).try(:date_end)) %>">
-            <%= toLocalDate(noticeboard.dates.try(:first).try(:date_end)) %>
+            <%= to_local_date(noticeboard.dates.try(:first).try(:date_end)) %>
           </td>
           <td data-sort="<%= DateTime.parse(noticeboard.updated_at).to_i %>">
-            <%= toLocalDateTime(noticeboard.updated_at) %>
+            <%= to_local_date_time(noticeboard.updated_at) %>
           </td>
           <td data-sort="<%= DateTime.parse(noticeboard.created_at).to_i %>">
-            <%= toLocalDateTime(noticeboard.created_at) %>
+            <%= to_local_date_time(noticeboard.created_at) %>
           </td>
           <% if editor? %>
             <td><%= noticeboard.data_provider.try(:name) %></td>

--- a/app/views/noticeboards/index.html.erb
+++ b/app/views/noticeboards/index.html.erb
@@ -44,8 +44,12 @@
           <td><%= noticeboard.generic_item_messages.count %></td>
           <td><%= toLocalDate(noticeboard.dates.try(:first).try(:date_start)) %></td>
           <td><%= toLocalDate(noticeboard.dates.try(:first).try(:date_end)) %></td>
-          <td><%= toLocalDateTime(noticeboard.updated_at) %></td>
-          <td><%= toLocalDateTime(noticeboard.created_at) %></td>
+          <td data-sort="<%= DateTime.parse(noticeboard.updated_at).to_i %>">
+            <%= toLocalDateTime(noticeboard.updated_at) %>
+          </td>
+          <td data-sort="<%= DateTime.parse(noticeboard.created_at).to_i %>">
+            <%= toLocalDateTime(noticeboard.created_at) %>
+          </td>
           <% if editor? %>
             <td><%= noticeboard.data_provider.try(:name) %></td>
             <td align="center"><%= visibility_switch(noticeboard, "Noticeboard") %></td>

--- a/app/views/noticeboards/index.html.erb
+++ b/app/views/noticeboards/index.html.erb
@@ -42,8 +42,12 @@
           </td>
           <td><%= noticeboard.categories.first.try(:name) || "" %></td>
           <td><%= noticeboard.generic_item_messages.count %></td>
-          <td><%= toLocalDate(noticeboard.dates.try(:first).try(:date_start)) %></td>
-          <td><%= toLocalDate(noticeboard.dates.try(:first).try(:date_end)) %></td>
+          <td data-sort="<%= to_unix_timestamp(noticeboard.dates.try(:first).try(:date_start)) %>">
+            <%= toLocalDate(noticeboard.dates.try(:first).try(:date_start)) %>
+          </td>
+          <<td data-sort="<%= to_unix_timestamp(noticeboard.dates.try(:first).try(:date_end)) %>">
+            <%= toLocalDate(noticeboard.dates.try(:first).try(:date_end)) %>
+          </td>
           <td data-sort="<%= DateTime.parse(noticeboard.updated_at).to_i %>">
             <%= toLocalDateTime(noticeboard.updated_at) %>
           </td>

--- a/app/views/offers/index.html.erb
+++ b/app/views/offers/index.html.erb
@@ -27,8 +27,12 @@
         <tr>
           <th scope="row"><%= offer.id %></th>
           <td><%= link_to offer.title, edit_offer_path(offer.id) %></td>
-          <td><%= toLocalDate(offer.publication_date.try(:to_date)) %></td>
-          <td><%= toLocalDate(offer.dates.try(:first).try(:date_end)) %></td>
+          <td data-sort="<%= to_unix_timestamp(offer.publication_date.try(:to_date)) %>">
+            <%= toLocalDate(offer.publication_date.try(:to_date)) %>
+          </td>
+          <td data-sort="<%= to_unix_timestamp(offer.dates.try(:first).try(:date_end)) %>">
+            <%= toLocalDate(offer.dates.try(:first).try(:date_end)) %>
+          </td>
           <td data-sort="<%= DateTime.parse(offer.updated_at).to_i %>">
             <%= toLocalDateTime(offer.updated_at) %>
           </td>

--- a/app/views/offers/index.html.erb
+++ b/app/views/offers/index.html.erb
@@ -29,8 +29,12 @@
           <td><%= link_to offer.title, edit_offer_path(offer.id) %></td>
           <td><%= toLocalDate(offer.publication_date.try(:to_date)) %></td>
           <td><%= toLocalDate(offer.dates.try(:first).try(:date_end)) %></td>
-          <td><%= toLocalDateTime(offer.updated_at) %></td>
-          <td><%= toLocalDateTime(offer.created_at) %></td>
+          <td data-sort="<%= DateTime.parse(offer.updated_at).to_i %>">
+            <%= toLocalDateTime(offer.updated_at) %>
+          </td>
+          <td data-sort="<%= DateTime.parse(offer.created_at).to_i %>">
+            <%= toLocalDateTime(offer.created_at) %>
+          </td>
           <% if editor? %>
             <td><%= offer.data_provider.try(:name) %></td>
           <% end %>

--- a/app/views/offers/index.html.erb
+++ b/app/views/offers/index.html.erb
@@ -28,16 +28,16 @@
           <th scope="row"><%= offer.id %></th>
           <td><%= link_to offer.title, edit_offer_path(offer.id) %></td>
           <td data-sort="<%= to_unix_timestamp(offer.publication_date.try(:to_date)) %>">
-            <%= toLocalDate(offer.publication_date.try(:to_date)) %>
+            <%= to_local_date(offer.publication_date.try(:to_date)) %>
           </td>
           <td data-sort="<%= to_unix_timestamp(offer.dates.try(:first).try(:date_end)) %>">
-            <%= toLocalDate(offer.dates.try(:first).try(:date_end)) %>
+            <%= to_local_date(offer.dates.try(:first).try(:date_end)) %>
           </td>
           <td data-sort="<%= DateTime.parse(offer.updated_at).to_i %>">
-            <%= toLocalDateTime(offer.updated_at) %>
+            <%= to_local_date_time(offer.updated_at) %>
           </td>
           <td data-sort="<%= DateTime.parse(offer.created_at).to_i %>">
-            <%= toLocalDateTime(offer.created_at) %>
+            <%= to_local_date_time(offer.created_at) %>
           </td>
           <% if editor? %>
             <td><%= offer.data_provider.try(:name) %></td>

--- a/app/views/point_of_interests/index.html.erb
+++ b/app/views/point_of_interests/index.html.erb
@@ -26,8 +26,12 @@
         <tr>
           <th scope="row"><%= poi.id %></th>
           <td><%= link_to poi.name, edit_point_of_interest_path(poi.id) %></td>
-          <td><%= toLocalDateTime(poi.updated_at) %></td>
-          <td><%= toLocalDateTime(poi.created_at) %></td>
+          <td data-sort="<%= DateTime.parse(poi.updated_at).to_i %>">
+            <%= toLocalDateTime(poi.updated_at) %>
+          </td>
+          <td data-sort="<%= DateTime.parse(poi.created_at).to_i %>">
+            <%= toLocalDateTime(poi.created_at) %>
+          </td>
           <% if editor? %>
             <td><%= poi.data_provider.try(:name) %></td>
             <td align="center"><%= visibility_switch(poi, "PointOfInterest") %></td>

--- a/app/views/point_of_interests/index.html.erb
+++ b/app/views/point_of_interests/index.html.erb
@@ -27,10 +27,10 @@
           <th scope="row"><%= poi.id %></th>
           <td><%= link_to poi.name, edit_point_of_interest_path(poi.id) %></td>
           <td data-sort="<%= DateTime.parse(poi.updated_at).to_i %>">
-            <%= toLocalDateTime(poi.updated_at) %>
+            <%= to_local_date_time(poi.updated_at) %>
           </td>
           <td data-sort="<%= DateTime.parse(poi.created_at).to_i %>">
-            <%= toLocalDateTime(poi.created_at) %>
+            <%= to_local_date_time(poi.created_at) %>
           </td>
           <% if editor? %>
             <td><%= poi.data_provider.try(:name) %></td>

--- a/app/views/static_contents/index.html.erb
+++ b/app/views/static_contents/index.html.erb
@@ -36,11 +36,11 @@
                   locals: { static_content: static_content }
                 ) %>
           </td>
-          <td data-sort="<%= DateTime.parse(static_content.updated_at).to_i %>">         
-            <%= toLocalDateTime(static_content.updated_at) %>
+          <td data-sort="<%= DateTime.parse(static_content.updated_at).to_i %>">
+            <%= to_local_date_time(static_content.updated_at) %>
           </td>
           <td data-sort="<%= DateTime.parse(static_content.updated_at).to_i %>">
-            <%= toLocalDateTime(static_content.created_at) %>
+            <%= to_local_date_time(static_content.created_at) %>
           </td>
           <td align="right" class="text-nowrap">
             <%= link_to(

--- a/app/views/static_contents/index.html.erb
+++ b/app/views/static_contents/index.html.erb
@@ -36,8 +36,12 @@
                   locals: { static_content: static_content }
                 ) %>
           </td>
-          <td><%= toLocalDateTime(static_content.updated_at) %></td>
-          <td><%= toLocalDateTime(static_content.created_at) %></td>
+          <td data-sort="<%= DateTime.parse(static_content.updated_at).to_i %>">         
+            <%= toLocalDateTime(static_content.updated_at) %>
+          </td>
+          <td data-sort="<%= DateTime.parse(static_content.updated_at).to_i %>">
+            <%= toLocalDateTime(static_content.created_at) %>
+          </td>
           <td align="right" class="text-nowrap">
             <%= link_to(
                   "Bearbeiten",

--- a/app/views/survey_comments/index.html.erb
+++ b/app/views/survey_comments/index.html.erb
@@ -34,7 +34,7 @@
             <% end %>
           </td>
           <td data-sort="<%= DateTime.parse(survey_comment.created_at).to_i %>">
-            <%= toLocalDateTime(survey_comment.created_at) %>
+            <%= to_local_date_time(survey_comment.created_at) %>
           </td>
           <% if editor? %>
             <td align="center"><%= visibility_switch(survey_comment, "Survey_Comment") %></td>

--- a/app/views/survey_comments/index.html.erb
+++ b/app/views/survey_comments/index.html.erb
@@ -33,7 +33,9 @@
               <%= survey_comment.message %>
             <% end %>
           </td>
-          <td><%= toLocalDateTime(survey_comment.created_at) %></td>
+          <td data-sort="<%= DateTime.parse(survey_comment.created_at).to_i %>">
+            <%= toLocalDateTime(survey_comment.created_at) %>
+          </td>
           <% if editor? %>
             <td align="center"><%= visibility_switch(survey_comment, "Survey_Comment") %></td>
           <% end %>

--- a/app/views/surveys/index.html.erb
+++ b/app/views/surveys/index.html.erb
@@ -37,8 +37,12 @@
           </td>
           <td><%= toLocalDate(survey.date.try(:date_start)) %></td>
           <td><%= toLocalDate(survey.date.try(:date_end)) %></td>
-          <td><%= toLocalDateTime(survey.updated_at) %></td>
-          <td><%= toLocalDateTime(survey.created_at) %></td>
+          <td data-sort="<%= DateTime.parse(survey.updated_at).to_i %>">
+            <%= toLocalDateTime(survey.updated_at) %>
+          </td>
+          <td data-sort="<%= DateTime.parse(survey.updated_at).to_i %>">
+            <%= toLocalDateTime(survey.created_at) %>
+          </td>
           <% if editor? %>
             <td><%= survey.data_provider.name %></td>
             <td align="center"><%= visibility_switch(survey, "Survey") %></td>

--- a/app/views/surveys/index.html.erb
+++ b/app/views/surveys/index.html.erb
@@ -35,8 +35,12 @@
                   survey.comments.count :
                     (link_to survey.comments.count, survey_comments_path(survey.id)) %>
           </td>
-          <td><%= toLocalDate(survey.date.try(:date_start)) %></td>
-          <td><%= toLocalDate(survey.date.try(:date_end)) %></td>
+          <td data-sort="<%= to_unix_timestamp(survey.date.try(:date_start)) %>">
+            <%= toLocalDate(survey.date.try(:date_start)) %>
+          </td>
+          <td data-sort="<%= to_unix_timestamp(survey.date.try(:date_end)) %>">
+            <%= toLocalDate(survey.date.try(:date_end)) %>
+          </td>
           <td data-sort="<%= DateTime.parse(survey.updated_at).to_i %>">
             <%= toLocalDateTime(survey.updated_at) %>
           </td>

--- a/app/views/surveys/index.html.erb
+++ b/app/views/surveys/index.html.erb
@@ -36,16 +36,16 @@
                     (link_to survey.comments.count, survey_comments_path(survey.id)) %>
           </td>
           <td data-sort="<%= to_unix_timestamp(survey.date.try(:date_start)) %>">
-            <%= toLocalDate(survey.date.try(:date_start)) %>
+            <%= to_local_date(survey.date.try(:date_start)) %>
           </td>
           <td data-sort="<%= to_unix_timestamp(survey.date.try(:date_end)) %>">
-            <%= toLocalDate(survey.date.try(:date_end)) %>
+            <%= to_local_date(survey.date.try(:date_end)) %>
           </td>
           <td data-sort="<%= DateTime.parse(survey.updated_at).to_i %>">
-            <%= toLocalDateTime(survey.updated_at) %>
+            <%= to_local_date_time(survey.updated_at) %>
           </td>
           <td data-sort="<%= DateTime.parse(survey.updated_at).to_i %>">
-            <%= toLocalDateTime(survey.created_at) %>
+            <%= to_local_date_time(survey.created_at) %>
           </td>
           <% if editor? %>
             <td><%= survey.data_provider.name %></td>

--- a/app/views/tours/index.html.erb
+++ b/app/views/tours/index.html.erb
@@ -26,8 +26,12 @@
         <tr>
           <th scope="row"><%= tour.id %></th>
           <td><%= link_to tour.name, edit_tour_path(tour.id) %></td>
-          <td><%= toLocalDateTime(tour.updated_at) %></td>
-          <td><%= toLocalDateTime(tour.created_at) %></td>
+          <td data-sort="<%= DateTime.parse(tour.updated_at).to_i %>">
+            <%= toLocalDateTime(tour.updated_at) %>
+          </td>
+          <td data-sort="<%= DateTime.parse(tour.created_at).to_i %>">
+            <%= toLocalDateTime(tour.created_at) %>
+          </td>
           <% if editor? %>
             <td><%= tour.data_provider.try(:name) %></td>
             <td align="center"><%= visibility_switch(tour, "Tour") %></td>

--- a/app/views/tours/index.html.erb
+++ b/app/views/tours/index.html.erb
@@ -27,10 +27,10 @@
           <th scope="row"><%= tour.id %></th>
           <td><%= link_to tour.name, edit_tour_path(tour.id) %></td>
           <td data-sort="<%= DateTime.parse(tour.updated_at).to_i %>">
-            <%= toLocalDateTime(tour.updated_at) %>
+            <%= to_local_date_time(tour.updated_at) %>
           </td>
           <td data-sort="<%= DateTime.parse(tour.created_at).to_i %>">
-            <%= toLocalDateTime(tour.created_at) %>
+            <%= to_local_date_time(tour.created_at) %>
           </td>
           <% if editor? %>
             <td><%= tour.data_provider.try(:name) %></td>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "leaflet-gesture-handling": "^1.2.2",
     "lodash": "^4.17.21",
     "lodash.template": "^4.5.0",
-    "moment": "^2.29.4",
     "popper.js": "^1.16.1",
     "startbootstrap-sb-admin-2": "4.0.6",
     "turbolinks": "^5.2.0"
@@ -43,7 +42,6 @@
     "webpack-dev-server": "^3.11.3"
   },
   "resolutions": {
-    "jquery": "3.4.1",
-    "moment": "^2.29.4"
+    "jquery": "3.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@rails/webpacker": "^5.2.2",
     "axios": "^0.26.1",
     "bootstrap": "^4.6.0",
-    "datatable-sorting-datetime-moment": "^1.0.1",
     "datatables.net": "^1.10.19",
     "datatables.net-fixedcolumns": "^4.1.0",
     "jquery": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2909,14 +2909,6 @@ cyclist@~0.2.2:
   resolved "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
 
-datatable-sorting-datetime-moment@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/datatable-sorting-datetime-moment/-/datatable-sorting-datetime-moment-1.0.1.tgz"
-  integrity sha512-9V1dvah9N3kU55CIK8PqR+WW5TvzGsQgSAw80L2CeHpX8gELVRTBwovuyYfqLO9fUDFP4VnttB8zgbj1//TUhw==
-  dependencies:
-    datatable "^2.0.2"
-    moment "^2.22.1"
-
 datatable@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/datatable/-/datatable-2.0.2.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2909,13 +2909,6 @@ cyclist@~0.2.2:
   resolved "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
 
-datatable@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/datatable/-/datatable-2.0.2.tgz"
-  integrity sha1-0FZtM1Tcml7qa9rLeAfuDy6Mq04=
-  dependencies:
-    underscore "1.4.x"
-
 datatables.net-bs4@1.10.19:
   version "1.10.19"
   resolved "https://registry.npmjs.org/datatables.net-bs4/-/datatables.net-bs4-1.10.19.tgz"
@@ -5116,7 +5109,7 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@^2.10.2, moment@^2.22.1, moment@^2.29.4:
+moment@^2.10.2:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
@@ -7620,11 +7613,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-underscore@1.4.x:
-  version "1.4.4"
-  resolved "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
-  integrity sha1-YaajIBBiKvoHljvzJSA88SI51gQ=
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This Pull Request introduces sorting with HTML data-sort (timestamp-integers) and remove moment.js

1. add sort for created_at and updated_at columns
2. add sort for date_start, date_end, and to_end columns
3. remove moment-related code and dependencies

SVA-1122