### PR TITLE
fix: error if create static content

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -310,7 +310,7 @@ class EventsController < ApplicationController
     def create_update_or_copy_mutation(update: false, is_copy: false)
       @event_params = event_params
       convert_params_for_graphql
-      Converter::Base.new.build_mutation("createEventRecord", @event_params, update, is_copy)
+      Converter::Base.new.build_mutation("createEventRecord", @event_params, update, "id", is_copy)
     end
 
     def convert_params_for_graphql

--- a/app/services/converter/base.rb
+++ b/app/services/converter/base.rb
@@ -1,6 +1,6 @@
 module Converter
   class Base
-    def build_mutation(name, data, update = false, is_copy = false, return_keys = "id")
+    def build_mutation(name, data, update = false, return_keys = "id", is_copy = false)
       data = cleanup(data) unless name.downcase.include?("update") || update
       data = copy(data) if is_copy
       data = convert_to_json(data)


### PR DESCRIPTION
the issue was due to incorrect arguments order passed to the buildMutation function from the commit 257354e8f6b946b831d05178633a7108d3e45f01

SVA-1144