### PR TITLE
feat(categories): render multiple noticeboards for different categories on dashboard

### DIFF
--- a/app/controllers/noticeboards_controller.rb
+++ b/app/controllers/noticeboards_controller.rb
@@ -6,9 +6,15 @@ class NoticeboardsController < ApplicationController
   before_action :init_graphql_client
 
   def index
+    @noticeboard_name = noticeboard_params[:name] || "Schwarzes Brett"
+    category_ids = noticeboard_params[:category_ids]
+
     results = @smart_village.query <<~GRAPHQL
       query {
-        genericItems(genericType: "Noticeboard") {
+        genericItems(
+          genericType: "Noticeboard",
+          #{category_ids.present? ? "categoryIds: #{category_ids}" : ""}
+        ) {
           id
           categories {
             name
@@ -67,4 +73,10 @@ class NoticeboardsController < ApplicationController
                       end
     redirect_to noticeboards_path
   end
+
+  private
+
+    def noticeboard_params
+      params.permit(:name, category_ids: [])
+    end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -320,24 +320,32 @@
   <% end %>
 
   <% if visible_in_role?("role_noticeboard") %>
-    <div
-      class="d-flex flex-column col-12 col-lg-5 justify-content-between jumbotron p-0 bg-white shadow mr-lg-4"
-    >
-      <div class="d-flex justify-content-between align-items-center py-5 px-4">
-        <h4>
-          <i class="fas fa-fw fa-clipboard-list"></i> Schwarzes Brett
-        </h4>
-        <h5>
-          <%= @noticeboards.count %>
-        </h5>
-      </div>
+    <% @noticeboards.each do |noticeboard| %>
+      <div
+        class="d-flex flex-column col-12 col-lg-5 justify-content-between jumbotron p-0 bg-white shadow mr-lg-4"
+      >
+        <div class="d-flex justify-content-between align-items-center py-5 px-4">
+          <h4>
+            <i class="fas fa-fw fa-clipboard-list"></i> <%= noticeboard[:name] %>
+          </h4>
+          <h5>
+            <%= noticeboard[:items].count %>
+          </h5>
+        </div>
 
-      <div class="button-banner">
-        <%= link_to "/noticeboards", class: "btn btn-sm btn-primary shadow-sm" do %>
-          Alle anzeigen
-        <% end %>
+        <div class="button-banner">
+          <%= link_to(
+                noticeboards_path(
+                  category_ids: noticeboard[:category_ids],
+                  name: noticeboard[:name]
+                ),
+                class: "btn btn-sm btn-primary shadow-sm") do
+             %>
+            Alle anzeigen
+          <% end %>
+        </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
 
   <% if visible_in_role?("role_defect_report") %>

--- a/app/views/noticeboards/index.html.erb
+++ b/app/views/noticeboards/index.html.erb
@@ -1,5 +1,5 @@
 <div class="d-flex flex-wrap align-items-center row-gap justify-content-between mb-5">
-  <h1 class="h3 mb-0 pb-0 font-weight-bold mr-3">Schwarzes Brett</h1>
+  <h1 class="h3 mb-0 pb-0 font-weight-bold mr-3"><%= @noticeboard_name %></h1>
 </div>
 
 <div class="table-responsive pb-4">


### PR DESCRIPTION
- added loading of different categorized noticeboards if present through category settings, falling back to the default one to ensure backwards compatibility
- added ability to load categorized noticeboard overviews to be linked to from the dashboard with specific name and items

|dashboard|index|
|---|---|
|<img width="1231" alt="image" src="https://github.com/user-attachments/assets/caa0f435-da43-4f81-8f56-d15ff320a362">|<img width="1412" alt="image" src="https://github.com/user-attachments/assets/f80c490a-c221-4817-9fc2-8d5c43c943a6">|

SVAK-51